### PR TITLE
Make custom propTypes chainable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "jsx-a11y/img-has-alt": 0,
     "jsx-a11y/label-has-for": 0,
     "import/no-extraneous-dependencies": 0,
+    "import/prefer-default-export": 0,
     "no-console": 0,
     "no-unused-vars": 1,
     "react/sort-comp": 1,

--- a/libs/props/range.js
+++ b/libs/props/range.js
@@ -1,10 +1,11 @@
+import { createPropType } from './util';
 
 module.exports = (min, max) => {
-  return (props, propName, componentName) => {
+  return createPropType((props, propName, componentName) => {
     const value = props[propName];
 
     if (value < min || value > max) {
       return new Error(`Invalid prop ${propName} of ${componentName}, should between ${min} and ${max}.`);
     }
-  }
+  });
 }

--- a/libs/props/util.js
+++ b/libs/props/util.js
@@ -1,0 +1,8 @@
+import { PropTypes } from 'react';
+
+export function createPropType(propType) {
+  // Chainable isRequired and more
+  propType.isRequired = PropTypes.any.isRequired;
+
+  return propType;
+}

--- a/libs/view/index.js
+++ b/libs/view/index.js
@@ -29,8 +29,10 @@ export default class View extends Component {
   }
 }
 
+/* eslint-disable */
 View.propTypes = {
-  if: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]),
-  show: PropTypes.oneOfType([PropTypes.bool, PropTypes.number, PropTypes.string]),
+  if: PropTypes.any,
+  show: PropTypes.any,
   transition: PropTypes.string
 };
+/* eslint-enable */


### PR DESCRIPTION
自定义的PropTypes都需要通过util.createPropType来创建, 来确保自定义的类型可以chainable, 比如`isRequired`.

``` js
util.createPropType(propType<Function>)
```
