### PR TITLE
Fullfill markdown docs & fix issue #62

### DIFF
--- a/libs/markdown/index.js
+++ b/libs/markdown/index.js
@@ -55,7 +55,7 @@ export default class Markdown extends Component {
 
     const html = marked(this.props.children.replace(/:::\s?demo ([^:::]+):::/g, (match, p1, offset) => {
       return p1.replace(/(.+)\n([^]+)/, (match, p1, p2) => {
-        const id = offset.toString(36), code = p2.match(/```.*\n([^]+)```/)[1], component = transform(`<div>${code}</div>`, {
+        const id = offset.toString(36), code = p2.match(/```.*\n([^]+)```/)[1].replace(/this/g, 'context'), component = transform(`<div>${code}</div>`, {
           presets: ['es2015', 'react']
         }).code.replace(/React.createElement/, 'return React.createElement');
 

--- a/site/docs/zh-CN/loading.md
+++ b/site/docs/zh-CN/loading.md
@@ -25,9 +25,9 @@
 
 ```html
 <div>
-  <Button type="primary" onClick={context.onClick.bind(context)}>显示整页加载，3 秒后消失</Button>
+  <Button type="primary" onClick={this.onClick.bind(this)}>显示整页加载，3 秒后消失</Button>
   {
-    context.state.fullscreen && <Loading fullscreen={true} />
+    this.state.fullscreen && <Loading fullscreen={true} />
   }
 </div>
 ```

--- a/site/docs/zh-CN/message-box.md
+++ b/site/docs/zh-CN/message-box.md
@@ -1,0 +1,80 @@
+## Message box 信息提示
+模拟系统的消息提示框而实现的一套模态对话框组件，用于消息提示、成功提示、错误提示、询问信息。
+
+### 消息提示
+
+当用户进行操作时会被触发，该对话框中断用户操作，直到用户确认知晓后才可关闭。
+
+:::demo 调用`$alert`方法即可打开消息提示，它模拟了系统的 `alert`，无法通过按下 ESC 或点击框外关闭。此例中接收了两个参数，`message`和`title`。值得一提的是，窗口被关闭后，它默认会返回一个`Promise`对象便于进行后续操作的处理。若不确定浏览器是否支持`Promise`，可自行引入第三方 polyfill 或像本例一样使用回调进行后续处理。
+
+```html
+<Button type="text" onClick={this.onClick.bind(this, 'alpha')}>点击打开 Message Box</Button>
+```
+:::
+
+### 确认消息
+
+提示用户确认其已经触发的动作，并询问是否进行此操作时会用到此对话框。
+
+:::demo 调用`$confirm`方法即可打开消息提示，它模拟了系统的 `confirm`。Message Box 组件也拥有极高的定制性，我们可以传入`options`作为第三个参数，它是一个字面量对象。`type`字段表明消息类型，可以为`success`，`error`，`info`和`warning`，无效的设置将会被忽略。注意，第二个参数`title`必须定义为`String`类型，如果是`Object`，会被理解为`options`。在这里我们用了 Promise 来处理后续响应。
+
+```html
+<Button type="text" onClick={this.onClick.bind(this, 'beta')}>点击打开 Message Box</Button>
+```
+:::
+
+### 提交内容
+
+当用户进行操作时会被触发，中断用户操作，提示用户进行输入的对话框。
+
+:::demo 调用`$prompt`方法即可打开消息提示，它模拟了系统的 `prompt`。可以用`inputPattern`字段自己规定匹配模式，或者用`inputValidator`规定校验函数，可以返回`Boolean`或`String`，`Boolean`为`false`或字符串时均表示校验未通过，`String`相当于定义了`inputErrorMessage`字段。此外，可以用`inputPlaceholder`字段来定义输入框的占位符。
+
+```html
+<Button type="text">点击打开 Message Box</Button>
+```
+:::
+
+### 自定义
+
+可自定义配置不同内容。
+
+:::demo 以上三个方法都是对`$msgbox`方法的再包装。本例直接调用`$msgbox`方法，使用了`showCancelButton`字段，用于显示取消按钮。另外可使用`cancelButtonClass`为其添加自定义样式，使用`cancelButtonText`来自定义按钮文本。Confirm 按钮也具有相同的字段，在文末的字段说明中有完整的字段列表。
+
+```html
+<Button type="text" onClick={this.onClick.bind(this, 'delta')}>点击打开 Message Box</Button>
+```
+:::
+
+### 全局方法
+
+Element 为 Vue.prototype 添加了如下全局方法：$msgbox, $alert, $confirm 和 $prompt。因此在 vue instance 中可以采用本页面中的方式调用 `MessageBox`。
+
+### 单独引用
+
+单独引入 `MessageBox`:
+
+```javascript
+import { MessageBox } from 'element-ui';
+```
+
+对应于上述四个全局方法的调用方法依次为：MessageBox, MessageBox.alert, MessageBox.confirm 和 MessageBox.prompt。
+
+### Options
+
+| 参数      | 说明          | 类型      | 可选值                           | 默认值  |
+|---------- |-------------- |---------- |--------------------------------  |-------- |
+| title | MessageBox 标题 | string | — | — |
+| message | MessageBox 消息正文内容 | string | — | — |
+| type | 消息类型，用于显示图标 | string | success/info/<br>warning/error | — |
+| lockScroll | 是否在 MessageBox 出现时将 body 滚动锁定 | boolean | — | true |
+| showCancelButton | 是否显示取消按钮 | boolean | — | false（以 confirm 和 prompt 方式调用时为 true） |
+| showConfirmButton | 是否显示确定按钮 | boolean | — | true |
+| cancelButtonText | 取消按钮的文本内容 | string | — | 取消 |
+| confirmButtonText | 确定按钮的文本内容 | string | — | 确定 |
+| cancelButtonClass | 取消按钮的自定义类名 | string | — | — |
+| confirmButtonClass | 确定按钮的自定义类名 | string | — | — |
+| showInput | 是否显示输入框 | boolean | — | false（以 prompt 方式调用时为 true）|
+| inputPlaceholder | 输入框的占位符 | string | — | — |
+| inputPattern | 输入框的校验表达式 | regexp | — | — |
+| inputValidator | 输入框的校验函数。可以返回布尔值或字符串，若返回一个字符串, 则返回结果会被赋值给 inputErrorMessage | function | — | — |
+| inputErrorMessage | 校验未通过时的提示文本 | string | — | 输入的数据不合法! |

--- a/site/docs/zh-CN/message.md
+++ b/site/docs/zh-CN/message.md
@@ -1,0 +1,65 @@
+## Message 消息提示
+
+常用于主动操作后的反馈提示。与 Notification 的区别是后者更多用于系统级通知的被动提醒。
+
+### 基础用法
+
+从顶部出现，3 秒后自动消失。
+
+:::demo Message 在配置上与 Notification 非常类似，所以部分 options 在此不做详尽解释，文末有 options 列表，可以结合 Notification 的文档理解它们。Element 注册了一个`$message`方法用于调用，Message 可以接收一个字符串作为参数，它会被显示为正文内容。
+
+```html
+<Button plain={true} onClick={this.onClick.bind(this, 'alpha', 'info')}>打开消息提示</Button>
+```
+:::
+
+### 不同状态
+
+用来显示「成功、警告、消息、错误」类的操作反馈。
+
+:::demo 当需要自定义更多属性时，Message 也可以接收一个对象为参数。比如，设置`type`字段可以定义不同的状态，默认为`info`。此时正文内容以`message`的值传入。同时，我们也为 Message 的各种 type 注册了方法，可以在不传入`type`字段的情况下像`open4`那样直接调用。
+
+```html
+<Button plain={true} onClick={this.onClick.bind(this, 'beta', 'success')}>成功</Button>
+<Button plain={true} onClick={this.onClick.bind(this, 'beta', 'warning')}>警告</Button>
+<Button plain={true} onClick={this.onClick.bind(this, 'beta', 'info')}>消息</Button>
+<Button plain={true} onClick={this.onClick.bind(this, 'beta', 'error')}>错误</Button>
+```
+:::
+
+### 可关闭
+
+可以添加关闭按钮。
+
+:::demo 默认的 Message 是不可以被人工关闭的，如果需要可手动关闭的 Message，可以使用`showClose`字段。此外，和 Notification 一样，Message 拥有可控的`duration`，设置`0`为不会被自动关闭，默认为 3000 毫秒。
+
+```html
+<Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'success', true)}>成功</Button>
+<Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'warning', true)}>警告</Button>
+<Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'info', true)}>消息</Button>
+<Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'error', true)}>错误</Button>
+```
+:::
+
+### 全局方法
+
+element 为 Vue.prototype 添加了全局方法 $message。因此在 vue instance 中可以采用本页面中的方式调用 `Message`。
+
+### 单独引用
+
+单独引入 `Message`：
+
+```javascript
+import { Message } from 'element-ui';
+```
+
+此时调用方法为 `Message(options)`。我们也为每个 type 定义了各自的方法，如 `Message.success(options)`。
+
+### Options
+| 参数      | 说明          | 类型      | 可选值                           | 默认值  |
+|---------- |-------------- |---------- |--------------------------------  |-------- |
+| message | 消息文字 | string | — | — |
+| type | 主题 | string | success/warning/info/error | info |
+| duration | 显示时间, 毫秒。设为 0 则不会自动关闭 | number | — | 3000 |
+| showClose | 是否显示关闭按钮 | boolean | — | false |
+| onClose | 关闭时的回调函数, 参数为被关闭的 message 实例 | function | — | — |

--- a/site/docs/zh-CN/radio.md
+++ b/site/docs/zh-CN/radio.md
@@ -1,0 +1,80 @@
+## Radio 单选框
+
+在一组备选项中进行单选
+
+### 基础用法
+
+由于选项默认可见，不宜过多，若选项过多，建议使用 Select 选择器。
+
+:::demo 要使用 Radio 组件，只需要设置`v-model`绑定变量，选中意味着变量的值为相应 Radio `label`属性的值，`label`可以是`String`或者`Number`。
+
+```html
+<Radio value="1" checked={this.state.alpha === '1'} onChange={e => this.onChange('alpha', e, '1')}>备选项</Radio>
+<Radio value="2" checked={this.state.alpha === '2'} onChange={e => this.onChange('alpha', e, '2')}>备选项</Radio>
+```
+:::
+
+### 禁用状态
+
+单选框不可用的状态。
+
+:::demo 注意：请牢记，选中的条件是绑定的变量值等于`label`中的值。只要在`el-radio`元素中设置`disabled`属性即可，它接受一个`Boolean`，`true`为禁用。
+
+```html
+<Radio value="1" disabled={true}>备选项</Radio>
+<Radio value="2" disabled={true}>备选项</Radio>
+```
+:::
+
+### 单选框组
+
+适用于在多个互斥的选项中选择的场景
+
+:::demo 结合`el-radio-group`元素和子元素`el-radio`可以实现单选组，在`el-radio-group`中绑定`v-model`，在`el-radio`中设置好`label`即可，无需再给每一个`el-radio`绑定变量，另外，还提供了`change`事件来响应变化，它会传入一个参数`value`。
+
+```html
+<Radio.Group value={this.state.charlie} onChange={this.onChange.bind(this, 'charlie')}>
+  <Radio value="3">备选项</Radio>
+  <Radio value="6">备选项</Radio>
+  <Radio value="9">备选项</Radio>
+</Radio.Group>
+```
+:::
+
+### 按钮样式
+
+按钮样式的单选组合。
+
+:::demo 只需要把`el-radio`元素换成`el-radio-button`元素即可，此外，Element 还提供了`size`属性给按钮组，支持`large`和`small`两种（如果不设定为默认）。
+
+```html
+<Radio.Group value={this.state.delta} onChange={this.onChange.bind(this, 'delta')}>
+  <Radio.Button value="上海" />
+  <Radio.Button value="北京" />
+  <Radio.Button value="广州" disabled={true} />
+  <Radio.Button value="深圳" />
+</Radio.Group>
+```
+:::
+
+### Radio Attributes
+| 参数      | 说明    | 类型      | 可选值       | 默认值   |
+|---------- |-------- |---------- |-------------  |-------- |
+| label     | Radio 的 value   | string,number    |       —        |      —   |
+| disabled  | 是否禁用    | boolean   | — | false   |
+
+### Radio-group Attributes
+| 参数      | 说明    | 类型      | 可选值       | 默认值   |
+|---------- |-------- |---------- |-------------  |-------- |
+| size     | Radio 按钮组尺寸   | string  | large, small  |    —     |
+
+### Radio-group Events
+| 事件名称 | 说明 | 回调参数 |
+|---------- |-------- |---------- |
+| change  | 绑定值变化时触发的事件 |  选中的 Radio label 值  |
+
+### Radio-button Attributes
+| 参数      | 说明    | 类型      | 可选值       | 默认值   |
+|---------- |-------- |---------- |-------------  |-------- |
+| label     | Radio 的 value  | string,number  |        —       |     —    |
+| disabled  | 是否禁用    | boolean   | — | false   |

--- a/site/pages/index.js
+++ b/site/pages/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import './style/base.scss';
-import './style/highlight.css';
 import '../../themes/default/index.css';
+import './style/highlight.css';
+import './style/base.scss';
 
 import Alert from './alert';
 import Layout from './layout';
@@ -37,7 +37,7 @@ class App extends React.Component {
     super(props);
 
     this.state = {
-      page: 'layout' // Do not change this line
+      page: location.hash.substr(1) || 'layout' // Do not change this line
     };
   }
 

--- a/site/pages/message-box/index.js
+++ b/site/pages/message-box/index.js
@@ -1,52 +1,14 @@
 import './style.scss';
 
 import React from 'react';
-import { MessageBox, Message, Button } from '../../../src';
+import { Component, Markdown } from '../../../libs';
+import template from '../../docs/zh-CN/message-box.md';
+
+import { MessageBox } from '../../../src';
 
 export default class Playground extends React.Component {
   render() {
-    return (
-      <div>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h2>Message box 信息提示</h2>
-            <p>模拟系统的消息提示框而实现的一套模态对话框组件，用于消息提示、成功提示、错误提示、询问信息。</p>
-            <h3>消息提示</h3>
-            <p>当用户进行操作时会被触发，该对话框中断用户操作，直到用户确认知晓后才可关闭。</p>
-          </div>
-          <div className="demo-content demo-message-box">
-            <Button type="text" onClick={this.onClick.bind(this, 'alpha')}>点击打开 Message Box</Button>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>确认消息</h3>
-            <p>提示用户确认其已经触发的动作，并询问是否进行此操作时会用到此对话框。</p>
-          </div>
-          <div className="demo-content demo-message-box">
-            <Button type="text" onClick={this.onClick.bind(this, 'beta')}>点击打开 Message Box</Button>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>提交内容</h3>
-            <p>当用户进行操作时会被触发，中断用户操作，提示用户进行输入的对话框。</p>
-          </div>
-          <div className="demo-content demo-message-box">
-            <Button type="text">点击打开 Message Box</Button>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>自定义</h3>
-            <p>可自定义配置不同内容。</p>
-          </div>
-          <div className="demo-content demo-message-box">
-            <Button type="text" onClick={this.onClick.bind(this, 'delta')}>点击打开 Message Box</Button>
-          </div>
-        </section>
-      </div>
-    )
+    return <Markdown context={this} component="MessageBox">{template}</Markdown>
   }
 
   onClick(type) {

--- a/site/pages/message-box/style.scss
+++ b/site/pages/message-box/style.scss
@@ -1,3 +1,5 @@
-.demo-message-box  {
-  
+.demo-box.demo-message {
+  .el-button + .el-button {
+    margin-left: 10px;
+  }
 }

--- a/site/pages/message/index.js
+++ b/site/pages/message/index.js
@@ -1,49 +1,14 @@
 import './style.scss';
 
 import React from 'react';
-import { Message, Button } from '../../../src';
+import { Component, Markdown } from '../../../libs';
+import template from '../../docs/zh-CN/message.md';
+
+import { Message } from '../../../src';
 
 export default class Playground extends React.Component {
   render() {
-    return (
-      <div>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h2>Message 消息提示</h2>
-            <p>常用于主动操作后的反馈提示。与 Notification 的区别是后者更多用于系统级通知的被动提醒。</p>
-            <h3>基础用法</h3>
-            <p>从顶部出现，3 秒后自动消失。</p>
-          </div>
-          <div className="demo-content demo-message">
-            <Button plain={true} onClick={this.onClick.bind(this, 'alpha', 'info')}>打开消息提示</Button>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>不同状态</h3>
-            <p>用来显示「成功、警告、消息、错误」类的操作反馈。</p>
-          </div>
-          <div className="demo-content demo-message">
-            <Button plain={true} onClick={this.onClick.bind(this, 'beta', 'success')}>成功</Button>
-            <Button plain={true} onClick={this.onClick.bind(this, 'beta', 'warning')}>警告</Button>
-            <Button plain={true} onClick={this.onClick.bind(this, 'beta', 'info')}>消息</Button>
-            <Button plain={true} onClick={this.onClick.bind(this, 'beta', 'error')}>错误</Button>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>可关闭</h3>
-            <p>可以添加关闭按钮。</p>
-          </div>
-          <div className="demo-content demo-message">
-            <Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'success', true)}>成功</Button>
-            <Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'warning', true)}>警告</Button>
-            <Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'info', true)}>消息</Button>
-            <Button plain={true} onClick={this.onClick.bind(this, 'charlie', 'error', true)}>错误</Button>
-          </div>
-        </section>
-      </div>
-    )
+    return <Markdown context={this} component="Message">{template}</Markdown>
   }
 
   onClick(id, type, showClose) {

--- a/site/pages/message/style.scss
+++ b/site/pages/message/style.scss
@@ -1,3 +1,5 @@
-.demo-message .el-button {
-    margin-right: 10px;
+.demo-box.demo-message {
+  .el-button + .el-button {
+    margin-left: 10px;
+  }
 }

--- a/site/pages/radio/index.js
+++ b/site/pages/radio/index.js
@@ -1,7 +1,8 @@
 import './style.scss';
 
 import React from 'react';
-import { Radio } from '../../../src';
+import { Component, Markdown } from '../../../libs';
+import template from '../../docs/zh-CN/radio.md';
 
 export default class Playground extends React.Component {
   constructor(props) {
@@ -13,59 +14,21 @@ export default class Playground extends React.Component {
       delta: '北京'
     }
   }
+
   render() {
-    return (
-      <div>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h2>Radio 单选框</h2>
-            <p>在一组备选项中进行单选</p>
-            <h3>基础用法</h3>
-            <p>由于选项默认可见，不宜过多，若选项过多，建议使用 Select 选择器。</p>
-          </div>
-          <div className="demo-content demo-radio">
-            <Radio value="1" checked={this.state.alpha === '1'} onChange={e => this.setState({ alpha: e.target.checked && '1' })}>备选项</Radio>
-            <Radio value="2" checked={this.state.alpha === '2'} onChange={e => this.setState({ alpha: e.target.checked && '2' })}>备选项</Radio>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>禁用状态</h3>
-            <p>单选框不可用的状态。</p>
-          </div>
-          <div className="demo-content demo-radio">
-            <Radio value="1" disabled={true}>备选项</Radio>
-            <Radio value="2" disabled={true}>备选项</Radio>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>单选框组</h3>
-            <p>适用于在多个互斥的选项中选择的场景</p>
-          </div>
-          <div className="demo-content demo-radio">
-            <Radio.Group value={this.state.charlie} onChange={e => this.setState({ charlie: e.target.value })}>
-              <Radio value="3">备选项</Radio>
-              <Radio value="6">备选项</Radio>
-              <Radio value="9">备选项</Radio>
-            </Radio.Group>
-          </div>
-        </section>
-        <section className="demo-section">
-          <div className="demo-header">
-            <h3>按钮样式</h3>
-            <p>按钮样式的单选组合。</p>
-          </div>
-          <div className="demo-content demo-radio">
-            <Radio.Group value={this.state.delta} onChange={e => this.setState({ delta: e.target.value })}>
-              <Radio.Button value="上海" />
-              <Radio.Button value="北京" />
-              <Radio.Button value="广州" disabled={true} />
-              <Radio.Button value="深圳" />
-            </Radio.Group>
-          </div>
-        </section>
-      </div>
-    )
+    return <Markdown context={this} component="Radio">{template}</Markdown>
+  }
+
+  onChange(type, event, value) {
+    switch (type) {
+      case 'alpha':
+        this.setState({ alpha: event.target.checked && value }); break;
+      case 'charlie':
+        this.setState({ charlie: event.target.value }); break;
+      case 'delta':
+        this.setState({ delta: event.target.value }); break;
+      default:
+        break;
+    }
   }
 }

--- a/site/pages/style/base.scss
+++ b/site/pages/style/base.scss
@@ -89,12 +89,6 @@ body {
         color: #1f2f3d;
       }
 
-      p {
-        margin: 1em 0;
-        font-size: 14px;
-        color: #5e6d82;
-      }
-
       table {
         border-collapse: collapse;
         width: 100%;
@@ -180,12 +174,11 @@ body {
     line-height: 1.8;
     font-size: 12px;
     background-color: #f9fafc;
-    margin-bottom: 25px;
+    display: flex;
 
     pre {
       overflow-x: auto;
       padding: 18px 24px;
-      height: 100%;
     }
   }
 
@@ -230,4 +223,10 @@ body {
       transform: translateX(10px);
     }
   }
+}
+
+.content p {
+  margin: 1em 0;
+  font-size: 14px;
+  color: #5e6d82;
 }


### PR DESCRIPTION
Markdown文档可以使用`this`来代替`context`, fix issue https://github.com/eleme/element-react/issues/62