### PR TITLE
fix: pagination组件pageSize属性不生效问题 issue #209

### DIFF
--- a/src/pagination/Pagination.jsx
+++ b/src/pagination/Pagination.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { Component, PropTypes } from '../../libs';
 import Pager from './Pager';
 import Select from '../select';
@@ -27,6 +26,7 @@ const Next = (props) => {
 }
 
 class Sizes extends Component{
+
   render(){
     const { onSizeChange, internalPageSize } = this.props;
 
@@ -93,11 +93,12 @@ export default class Pagination extends Component{
   constructor(props, context){
     super(props, context);
 
-    const { currentPage, pageSizes,  pageSize, total, pageCount} = this.props;
+    const { currentPage, pageSizes,  pageSize, total, pageCount, layout } = this.props;
     let internalPageSize = 0;
-
-    if (Array.isArray(pageSizes)) {
+    if (layout.split(',').indexOf('sizes') > -1 && Array.isArray(pageSizes)) {
       internalPageSize = pageSizes.indexOf(pageSize) > -1 ? pageSize : pageSizes[0];
+    } else {
+      internalPageSize = pageSize
     }
 
     this.state = {
@@ -109,19 +110,19 @@ export default class Pagination extends Component{
   }
 
   componentWillReceiveProps(nextProps){
-    const { currentPage, pageSizes,  pageSize, total, pageCount} = this.props;
+    const { currentPage, pageSizes,  pageSize, total, pageCount } = this.props;
 
-    if(nextProps.currentPage != currentPage || 
-      nextProps.pageSizes != pageSizes || 
+    if(nextProps.currentPage != currentPage ||
+      nextProps.pageSizes != pageSizes ||
       nextProps.pageSize != pageSize ||
       nextProps.total != total ||
       nextProps.pageCount != pageCount){
 
       let internalPageSize = this.state.internalPageSize;
-      if (Array.isArray(nextProps.pageSizes)) {
+      if (nextProps.layout.split(',').indexOf('sizes') > -1 && Array.isArray(nextProps.pageSizes)) {
         internalPageSize = nextProps.pageSizes.indexOf(nextProps.pageSize) > -1 ?nextProps.pageSize : nextProps.pageSizes[0];
       }
-      
+
       this.setState({
         internalPageSize: internalPageSize,
         total: nextProps.total,


### PR DESCRIPTION
修复pagination组件pageSize属性不生效问题

what happened：
不论是否渲染sizes组件，程序都会执行pageSizes.indexOf(pageSize) > -1 ? pageSize : pageSizes[0]来设置pageSize的值，pageSizes的默认值为[10, 20, 30, 40, 50, 100]，如果用户设置的pageSize不在其中，所以就会一直为10

what i did:
如果不需要sizes组件，不进行上述判断，直接取pageSize的属性值