### PR TITLE
Make Input use native type.

### DIFF
--- a/src/input/Input.jsx
+++ b/src/input/Input.jsx
@@ -137,6 +137,7 @@ export default class Input extends Component {
           { typeof icon != 'string' ? icon : <i className={`el-input__icon el-icon-${icon}`} onClick={this.handleIconClick.bind(this)}>{prepend}</i> }
           <input { ...otherProps }
             ref="input"
+            type={type}
             className="el-input__inner"
             autoComplete={autoComplete}
             onChange={this.handleChange.bind(this)}


### PR DESCRIPTION
I tried to make a password input and noticed that the `type` prop was not being used for anything other than rendering a text area or a plain input. This change makes the rendered input inherit the `type` prop.

This bug is visible on the Element homepage as well. Look at the custom validation rules example here, the "password" field is just a plain text field: https://eleme.github.io/element-react/#/en-US/form