### PR TITLE
add left:0 to center loading-spinner

### DIFF
--- a/src/loading/Loading.jsx
+++ b/src/loading/Loading.jsx
@@ -76,7 +76,8 @@ export default class Loading extends Component {
               'is-full-screen': fullscreen
             })} style={{
               position: 'absolute',
-              display: 'inline-block'
+              display: 'inline-block',
+              left: 0
             }}>
               <svg className="circular" viewBox="25 25 50 50">
                 <circle className="path" cx="50" cy="50" r="20" fill="none" />


### PR DESCRIPTION
Hey, I just tried `element-react` and I really like it! Great work!
When I tried the `Loading`-component, the spinner appeared on the very right.
The following changes fixed this problem. I've attached before/after screenshots.
Changes in this pull request

- adds `left: 0` to svg-elem-wrapper to center loading spinner

I'm not sure if this is the right fix or if it should go somewhere else :)

![screen shot 2017-05-13 at 20 40 58](https://cloud.githubusercontent.com/assets/5221667/26028302/ee970068-381d-11e7-898e-651089a377e2.png)
![screen shot 2017-05-13 at 20 40 49](https://cloud.githubusercontent.com/assets/5221667/26028308/f8a38cac-381d-11e7-865e-36dcaac929bb.png)


