### PR TITLE
Fix for onVisibleChange event in Select

### DIFF
--- a/src/select/Select.jsx
+++ b/src/select/Select.jsx
@@ -130,6 +130,9 @@ class Select extends Component {
     }
 
     if (state.visible != this.state.visible) {
+      if (this.props.onVisibleChange) {
+        this.props.onVisibleChange(state.visible);
+      }
       this.onVisibleChange(state.visible);
     }
 


### PR DESCRIPTION
In Docs for the Select component (https://eleme.github.io/element-react/#/en-US/select) there is an onVisibleChange event, but seems like it doesn't work.
I looked at the source code of the component and did not find call onVisibleChange prop.

I did as in the Dropdown component.