### PR TITLE
Pass event instead of value to Input's onChange callback

### DIFF
--- a/src/input/Input.jsx
+++ b/src/input/Input.jsx
@@ -58,7 +58,7 @@ export default class Input extends Component {
     const { onChange } = this.props;
 
     if (onChange) {
-      onChange(e.target.value);
+      onChange(e);
     }
     this.resizeTextarea();
   }

--- a/src/input/__test__/Input_test.jsx
+++ b/src/input/__test__/Input_test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import Input from '../';
 
-// const delay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
+// const dInputelay = timeout => new Promise(resolve => setTimeout(resolve, timeout));
 
 describe('Input test', () => {
   it('create', () => {
@@ -65,4 +65,16 @@ describe('Input test', () => {
     expect(w.find('.el-textarea__inner').first().prop('style').resize).toBe('both');
   });
 
+  it('onChange', (done) => {
+    const updateValue = function(event) {
+      expect(event.target).toBeInstanceOf(EventTarget);
+      done();
+    };
+
+    const w = mount(
+      <Input onChange={updateValue} />
+    );
+
+    w.find('input').simulate('change');
+  });
 });


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [x] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

- In the Input's onChange callback, we were getting a string. This behaviour is inconsistent with other callbacks and with react's behaviour. Now, it gets an event just like any other component callback.
