### PR TITLE
Bind Dialog close event to <button> rather than <i>

### DIFF
--- a/src/dialog/Dialog.jsx
+++ b/src/dialog/Dialog.jsx
@@ -112,8 +112,8 @@ export default class Dialog extends Component {
                   <span className="el-dialog__title">{ title }</span>
                   {
                     showClose && (
-                      <button type="button" className="el-dialog__headerbtn">
-                        <i className="el-dialog__close el-icon el-icon-close" onClick={ e => this.close(e) }></i>
+                      <button type="button" className="el-dialog__headerbtn" onClick={ e => this.close(e)>
+                        <i className="el-dialog__close el-icon el-icon-close" }></i>
                       </button>
                     )
                   }


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [x] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

- Bind Dialog close event to <button> rather than <i>

Relative issuse

- #779 

> In Gecko nothing inside `<button>` gets mouse events, only the `<button>` itself.
> https://bugzilla.mozilla.org/show_bug.cgi?id=1459379
> https://bugzilla.mozilla.org/show_bug.cgi?id=1089326
