### PR TITLE
Fix typescript type error using Form component and onSubmit prop

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -662,7 +662,8 @@ declare namespace ElementReact {
     labelPosition?: 'right' | 'left' | 'top'
     labelWidth?: string | number
     labelSuffix?: string
-    inline?: boolean
+    inline?: boolean,
+    onSubmit?: () => void
   }
   interface FormItemProps extends ElementReactLibs.ComponentProps<{}> {
     label?: string


### PR DESCRIPTION
As described in https://github.com/ElemeFE/element-react/issues/1037

Using React With Typescript, the following : 

```
<Form onSubmit={handleSubmit}>
```

Causes a type error : 

```
Property 'onSubmit' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Form> & Readonly<FormProps> & Readonly<{ children?: ReactNode; }>'
```

I think this might resolve the problem.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [x] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

- Fix typescript type error using Form component and onSubmit prop