### PR TITLE
[Steps]: Change title property type to allow react node.

### DIFF
--- a/src/steps/Step.jsx
+++ b/src/steps/Step.jsx
@@ -73,7 +73,7 @@ export default class Step extends Component {
 }
 
 Step.propTypes = {
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   icon: PropTypes.string,
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   status: PropTypes.string,


### PR DESCRIPTION
When use React component in the `title` property of `Steps` component, there will be a warning. This type limitation is not necessary and makes a lot inconvenience. So I remove the type limitation to allow React component in `title`.

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [x] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

-
