### PR TITLE
[Slider]: add `triggerOnDragging` property for determine when to trigger `onChange` event on component.

### DIFF
--- a/site/docs/en-US/slider.md
+++ b/site/docs/en-US/slider.md
@@ -121,15 +121,15 @@ Selecting a range of values is supported.
 constructor(props) {
   super(props);
 
-  this.state = {
-    value: [4, 8]
-  }
+  this.onChange = (value) => {
+    this.setState({ value });
+  };
 }
 
 render() {
   return (
     <div className="block">
-      <Slider value={this.state.value} max={10} range={true} showStops={true} />
+      <Slider value={this.state.value} onChange={this.onChange} max={10} range showStops />
     </div>
   )
 }
@@ -165,11 +165,12 @@ render() {
 | max | maximum value | number | — | 100 |
 | disabled | whether Slider is disabled | boolean | — | false |
 | step | step size | number | — | 1 |
-| show-input | whether to display an input box, works when `range` is false | boolean | — | false |
-| show-input-controls | whether to display control buttons when `show-input` is true | boolean | — | true |
-| show-stops | whether to display breakpoints | boolean | — | false |
-| show-tooltip | whether to display tooltip value | boolean | — | true |
+| showInput | whether to display an input box, works when `range` is false | boolean | — | false |
+| showInputControls | whether to display control buttons when `show-input` is true | boolean | — | true |
+| showStops | whether to display breakpoints | boolean | — | false |
+| showTooltip | whether to display tooltip value | boolean | — | true |
 | range | whether to select a range | boolean | — | false |
+| triggerOnDragging | trigger `onChange` when mouse dragging | boolean | — | false |
 
 ## Events
 | Event Name | Description | Parameters |

--- a/site/docs/zh-CN/slider.md
+++ b/site/docs/zh-CN/slider.md
@@ -169,6 +169,7 @@ render() {
 | showInput | 是否显示输入框，仅在非范围选择时有效 | boolean | — | false |
 | showInputControls | 在显示输入框的情况下，是否显示输入框的控制按钮 | boolean | — | true|
 | showStops | 是否显示间断点 | boolean | — | false |
+| showTooltip | 是否显示值提示 | boolean | — | true |
 | range | 是否为范围选择 | boolean | — | false |
 | triggerOnDragging | 是否在拖动过程中触发 `onChange` | boolean | — | false |
 

--- a/site/docs/zh-CN/slider.md
+++ b/site/docs/zh-CN/slider.md
@@ -121,12 +121,16 @@ constructor(props) {
   this.state = {
     value: [4, 8]
   }
+
+  this.onChange = (value) => {
+    this.setState({ value });
+  };
 }
 
 render() {
   return (
     <div className="block">
-      <Slider value={this.state.value} max={10} range={true} showStops={true} />
+      <Slider value={this.state.value} onChange={this.onChange} max={10} range showStops />
     </div>
   )
 }
@@ -166,6 +170,7 @@ render() {
 | showInputControls | 在显示输入框的情况下，是否显示输入框的控制按钮 | boolean | — | true|
 | showStops | 是否显示间断点 | boolean | — | false |
 | range | 是否为范围选择 | boolean | — | false |
+| triggerOnDragging | 是否在拖动过程中触发 `onChange` | boolean | — | false |
 
 ### Events
 | 事件名称      | 说明    | 回调参数      |


### PR DESCRIPTION
In the old code, `onChange` event will be triggered on every mouse move. But this behavior will not be as expected in some scenario. So I added a property `triggerOnDragging` to control it in different mode. By default it will be `false` as the `onChange` event will only be trigger when mouse is released. When set it to `true`, every movement of dragging mouse will trigger `onChange`.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [x] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

- Add `triggerOnDragging` config for Slider.
- Simplified code.
- Fix range example in doc.