### PR TITLE
add typescript table row generics

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -603,7 +603,7 @@ declare namespace ElementReact {
   export class Slider extends ElementReactLibs.Component<SliderProps, {}> { }
 
   // Table
-  interface TableColumn {
+  interface TableColumn<RowType> {
     label?: string
     prop?: string
     property?: string
@@ -619,11 +619,11 @@ declare namespace ElementReact {
     fixed?: boolean | string
     filterMethod?: () => void
     filters?: Object[]
-    render?: (data? :Object, column? :Object, index? :number) => void
+    render?: (data? :RowType, column? :Object, index? :number) => void
   }
-  interface TableProps extends ElementReactLibs.ComponentProps<{}> {
-    columns?: TableColumn[]
-    data?: Object[]
+  interface TableProps<RowType> extends ElementReactLibs.ComponentProps<{}> {
+    columns?: TableColumn<RowType>[]
+    data?: RowType[]
     height?: number
     stripe?: boolean
     border?: boolean
@@ -635,7 +635,7 @@ declare namespace ElementReact {
     onSelectAll?(): void
     onSelectChange?(): void
   }
-  export class Table extends ElementReactLibs.Component<TableProps, {}> { }
+  export class Table<RowType extends Object = Object> extends ElementReactLibs.Component<TableProps<RowType>, {}> { }
 
   // Switch
   interface SwitchProps extends ElementReactLibs.ComponentProps<{}> {


### PR DESCRIPTION
In current version the following code with typescript would get error 
```javascript 
 const columns = {
    props: 'amount',
    title: 'amount',
    render: (row?: SymbolWithQuotation) => (
      //blablabla
    )
  }

const data: SymbolWithQuotation[] = [...some data];

<Table columns={columns} data={data} />
```

ts error: 
```
    属性“render”的类型不兼容。
            不能将类型“(row?: SymbolWithQuotation | undefined) => JSX.Element”分配给类型“(data?: Object | undefined, column?: Object | undefined, index?: number | undefined) => void”。
              参数“row”和“data” 的类型不兼容。
                不能将类型“Object | undefined”分配给类型“SymbolWithQuotation | undefined”。

.........others details
```

Add a generics to replace the data?: Object | undefined to  fix it 

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [x] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

- add typescript table row generics
