### PR TITLE
Canvas: Update hot reload

### DIFF
--- a/libs/markdown/canvas.jsx
+++ b/libs/markdown/canvas.jsx
@@ -24,6 +24,10 @@ export default class Canvas extends React.Component {
     this.renderSource(this.source[2])
   }
 
+  componentDidUpdate(){
+    this.renderSource(this.source[2])
+  }
+  
   blockControl() {
     this.setState({
       showBlock: !this.state.showBlock


### PR DESCRIPTION
【目前的问题】
比如当更新src目录下的Alert组件，此时组件库网站(element-react)必须要手动刷新，才能看到Alert组件修改的内容
【问题的原因】
在libs/markdown/canvas.jsx文件中，在生命周期componentDidMount中执行了this.renderSource(this.source[2])（热更新修改的代码），并且componentDidMount只会执行一次，所以修改了Alert组件内容，并不能自动刷新组件库网站（element-react）
【解决方案】
在libs/markdown/canvas.jsx文件中，在生命周期componentDidUpdate中，再次执行this.renderSource(this.source[2])，就可以实现修改任何src下组件内容，都会热更新组件库网站（element-react）
